### PR TITLE
feat: Add support for creating pod identity associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.30 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_eks_pod_identity_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_iam_policy.amazon_managed_service_prometheus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.appmesh_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.appmesh_envoy_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -486,6 +487,8 @@ No modules.
 | <a name="input_amazon_managed_service_prometheus_workspace_arns"></a> [amazon\_managed\_service\_prometheus\_workspace\_arns](#input\_amazon\_managed\_service\_prometheus\_workspace\_arns) | List of AMP Workspace ARNs to read and write metrics | `list(string)` | `[]` | no |
 | <a name="input_appmesh_controller_policy_name"></a> [appmesh\_controller\_policy\_name](#input\_appmesh\_controller\_policy\_name) | Custom name of the AppMesh Controller IAM policy | `string` | `null` | no |
 | <a name="input_appmesh_envoy_proxy_policy_name"></a> [appmesh\_envoy\_proxy\_policy\_name](#input\_appmesh\_envoy\_proxy\_policy\_name) | Custom name of the AppMesh Envoy Proxy IAM policy | `string` | `null` | no |
+| <a name="input_association_defaults"></a> [association\_defaults](#input\_association\_defaults) | Default values used across all Pod Identity associations created unless a more specific value is provided | `map(string)` | `{}` | no |
+| <a name="input_associations"></a> [associations](#input\_associations) | Map of Pod Identity associations to be created (map of maps) | `any` | `{}` | no |
 | <a name="input_attach_amazon_managed_service_prometheus_policy"></a> [attach\_amazon\_managed\_service\_prometheus\_policy](#input\_attach\_amazon\_managed\_service\_prometheus\_policy) | Determines whether to attach the Amazon Managed Service for Prometheus IAM policy to the role | `bool` | `false` | no |
 | <a name="input_attach_aws_appmesh_controller_policy"></a> [attach\_aws\_appmesh\_controller\_policy](#input\_attach\_aws\_appmesh\_controller\_policy) | Determines whether to attach the AppMesh Controller policy to the role | `bool` | `false` | no |
 | <a name="input_attach_aws_appmesh_envoy_proxy_policy"></a> [attach\_aws\_appmesh\_envoy\_proxy\_policy](#input\_attach\_aws\_appmesh\_envoy\_proxy\_policy) | Determines whether to attach the AppMesh Envoy Proxy policy to the role | `bool` | `false` | no |
@@ -558,6 +561,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_associations"></a> [associations](#output\_associations) | Map of Pod Identity associations created |
 | <a name="output_iam_policy_arn"></a> [iam\_policy\_arn](#output\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_iam_policy_id"></a> [iam\_policy\_id](#output\_iam\_policy\_id) | The policy's ID |
 | <a name="output_iam_policy_name"></a> [iam\_policy\_name](#output\_iam\_policy\_name) | Name of IAM policy |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.30 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -50,16 +50,20 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_cluster_autoscaler_pod_identity"></a> [cluster\_autoscaler\_pod\_identity](#module\_cluster\_autoscaler\_pod\_identity) | ../../ | n/a |
 | <a name="module_custom_pod_identity"></a> [custom\_pod\_identity](#module\_custom\_pod\_identity) | ../../ | n/a |
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
+| <a name="module_eks_one"></a> [eks\_one](#module\_eks\_one) | terraform-aws-modules/eks/aws | ~> 20.0 |
+| <a name="module_eks_two"></a> [eks\_two](#module\_eks\_two) | terraform-aws-modules/eks/aws | ~> 20.0 |
 | <a name="module_external_dns_pod_identity"></a> [external\_dns\_pod\_identity](#module\_external\_dns\_pod\_identity) | ../../ | n/a |
 | <a name="module_external_secrets_pod_identity"></a> [external\_secrets\_pod\_identity](#module\_external\_secrets\_pod\_identity) | ../../ | n/a |
 | <a name="module_mountpoint_s3_csi_pod_identity"></a> [mountpoint\_s3\_csi\_pod\_identity](#module\_mountpoint\_s3\_csi\_pod\_identity) | ../../ | n/a |
 | <a name="module_velero_pod_identity"></a> [velero\_pod\_identity](#module\_velero\_pod\_identity) | ../../ | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_iam_policy.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_iam_policy_document.override](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -71,6 +75,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_amazon_managed_service_prometheus_pod_identity_associations"></a> [amazon\_managed\_service\_prometheus\_pod\_identity\_associations](#output\_amazon\_managed\_service\_prometheus\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_amazon_managed_service_prometheus_pod_identity_iam_policy_arn"></a> [amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_policy\_arn](#output\_amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_amazon_managed_service_prometheus_pod_identity_iam_policy_id"></a> [amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_policy\_id](#output\_amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_amazon_managed_service_prometheus_pod_identity_iam_policy_name"></a> [amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_policy\_name](#output\_amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -78,6 +83,7 @@ No inputs.
 | <a name="output_amazon_managed_service_prometheus_pod_identity_iam_role_name"></a> [amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_role\_name](#output\_amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_amazon_managed_service_prometheus_pod_identity_iam_role_path"></a> [amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_role\_path](#output\_amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_amazon_managed_service_prometheus_pod_identity_iam_role_unique_id"></a> [amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_role\_unique\_id](#output\_amazon\_managed\_service\_prometheus\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_appmesh_controller_pod_identity_associations"></a> [aws\_appmesh\_controller\_pod\_identity\_associations](#output\_aws\_appmesh\_controller\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_appmesh_controller_pod_identity_iam_policy_arn"></a> [aws\_appmesh\_controller\_pod\_identity\_iam\_policy\_arn](#output\_aws\_appmesh\_controller\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_appmesh_controller_pod_identity_iam_policy_id"></a> [aws\_appmesh\_controller\_pod\_identity\_iam\_policy\_id](#output\_aws\_appmesh\_controller\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_appmesh_controller_pod_identity_iam_policy_name"></a> [aws\_appmesh\_controller\_pod\_identity\_iam\_policy\_name](#output\_aws\_appmesh\_controller\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -85,6 +91,7 @@ No inputs.
 | <a name="output_aws_appmesh_controller_pod_identity_iam_role_name"></a> [aws\_appmesh\_controller\_pod\_identity\_iam\_role\_name](#output\_aws\_appmesh\_controller\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_appmesh_controller_pod_identity_iam_role_path"></a> [aws\_appmesh\_controller\_pod\_identity\_iam\_role\_path](#output\_aws\_appmesh\_controller\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_appmesh_controller_pod_identity_iam_role_unique_id"></a> [aws\_appmesh\_controller\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_appmesh\_controller\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_appmesh_envoy_proxy_pod_identity_associations"></a> [aws\_appmesh\_envoy\_proxy\_pod\_identity\_associations](#output\_aws\_appmesh\_envoy\_proxy\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_appmesh_envoy_proxy_pod_identity_iam_policy_arn"></a> [aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_policy\_arn](#output\_aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_appmesh_envoy_proxy_pod_identity_iam_policy_id"></a> [aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_policy\_id](#output\_aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_appmesh_envoy_proxy_pod_identity_iam_policy_name"></a> [aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_policy\_name](#output\_aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -92,6 +99,7 @@ No inputs.
 | <a name="output_aws_appmesh_envoy_proxy_pod_identity_iam_role_name"></a> [aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_role\_name](#output\_aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_appmesh_envoy_proxy_pod_identity_iam_role_path"></a> [aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_role\_path](#output\_aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_appmesh_envoy_proxy_pod_identity_iam_role_unique_id"></a> [aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_appmesh\_envoy\_proxy\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_cloudwatch_observability_pod_identity_associations"></a> [aws\_cloudwatch\_observability\_pod\_identity\_associations](#output\_aws\_cloudwatch\_observability\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_cloudwatch_observability_pod_identity_iam_policy_arn"></a> [aws\_cloudwatch\_observability\_pod\_identity\_iam\_policy\_arn](#output\_aws\_cloudwatch\_observability\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_cloudwatch_observability_pod_identity_iam_policy_id"></a> [aws\_cloudwatch\_observability\_pod\_identity\_iam\_policy\_id](#output\_aws\_cloudwatch\_observability\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_cloudwatch_observability_pod_identity_iam_policy_name"></a> [aws\_cloudwatch\_observability\_pod\_identity\_iam\_policy\_name](#output\_aws\_cloudwatch\_observability\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -99,6 +107,7 @@ No inputs.
 | <a name="output_aws_cloudwatch_observability_pod_identity_iam_role_name"></a> [aws\_cloudwatch\_observability\_pod\_identity\_iam\_role\_name](#output\_aws\_cloudwatch\_observability\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_cloudwatch_observability_pod_identity_iam_role_path"></a> [aws\_cloudwatch\_observability\_pod\_identity\_iam\_role\_path](#output\_aws\_cloudwatch\_observability\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_cloudwatch_observability_pod_identity_iam_role_unique_id"></a> [aws\_cloudwatch\_observability\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_cloudwatch\_observability\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_ebs_csi_pod_identity_associations"></a> [aws\_ebs\_csi\_pod\_identity\_associations](#output\_aws\_ebs\_csi\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_ebs_csi_pod_identity_iam_policy_arn"></a> [aws\_ebs\_csi\_pod\_identity\_iam\_policy\_arn](#output\_aws\_ebs\_csi\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_ebs_csi_pod_identity_iam_policy_id"></a> [aws\_ebs\_csi\_pod\_identity\_iam\_policy\_id](#output\_aws\_ebs\_csi\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_ebs_csi_pod_identity_iam_policy_name"></a> [aws\_ebs\_csi\_pod\_identity\_iam\_policy\_name](#output\_aws\_ebs\_csi\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -106,6 +115,7 @@ No inputs.
 | <a name="output_aws_ebs_csi_pod_identity_iam_role_name"></a> [aws\_ebs\_csi\_pod\_identity\_iam\_role\_name](#output\_aws\_ebs\_csi\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_ebs_csi_pod_identity_iam_role_path"></a> [aws\_ebs\_csi\_pod\_identity\_iam\_role\_path](#output\_aws\_ebs\_csi\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_ebs_csi_pod_identity_iam_role_unique_id"></a> [aws\_ebs\_csi\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_ebs\_csi\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_efs_csi_pod_identity_associations"></a> [aws\_efs\_csi\_pod\_identity\_associations](#output\_aws\_efs\_csi\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_efs_csi_pod_identity_iam_policy_arn"></a> [aws\_efs\_csi\_pod\_identity\_iam\_policy\_arn](#output\_aws\_efs\_csi\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_efs_csi_pod_identity_iam_policy_id"></a> [aws\_efs\_csi\_pod\_identity\_iam\_policy\_id](#output\_aws\_efs\_csi\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_efs_csi_pod_identity_iam_policy_name"></a> [aws\_efs\_csi\_pod\_identity\_iam\_policy\_name](#output\_aws\_efs\_csi\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -113,6 +123,7 @@ No inputs.
 | <a name="output_aws_efs_csi_pod_identity_iam_role_name"></a> [aws\_efs\_csi\_pod\_identity\_iam\_role\_name](#output\_aws\_efs\_csi\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_efs_csi_pod_identity_iam_role_path"></a> [aws\_efs\_csi\_pod\_identity\_iam\_role\_path](#output\_aws\_efs\_csi\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_efs_csi_pod_identity_iam_role_unique_id"></a> [aws\_efs\_csi\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_efs\_csi\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_fsx_lustre_csi_pod_identity_associations"></a> [aws\_fsx\_lustre\_csi\_pod\_identity\_associations](#output\_aws\_fsx\_lustre\_csi\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_fsx_lustre_csi_pod_identity_iam_policy_arn"></a> [aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_policy\_arn](#output\_aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_fsx_lustre_csi_pod_identity_iam_policy_id"></a> [aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_policy\_id](#output\_aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_fsx_lustre_csi_pod_identity_iam_policy_name"></a> [aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_policy\_name](#output\_aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -120,6 +131,7 @@ No inputs.
 | <a name="output_aws_fsx_lustre_csi_pod_identity_iam_role_name"></a> [aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_role\_name](#output\_aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_fsx_lustre_csi_pod_identity_iam_role_path"></a> [aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_role\_path](#output\_aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_fsx_lustre_csi_pod_identity_iam_role_unique_id"></a> [aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_fsx\_lustre\_csi\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_gateway_controller_pod_identity_associations"></a> [aws\_gateway\_controller\_pod\_identity\_associations](#output\_aws\_gateway\_controller\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_gateway_controller_pod_identity_iam_policy_arn"></a> [aws\_gateway\_controller\_pod\_identity\_iam\_policy\_arn](#output\_aws\_gateway\_controller\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_gateway_controller_pod_identity_iam_policy_id"></a> [aws\_gateway\_controller\_pod\_identity\_iam\_policy\_id](#output\_aws\_gateway\_controller\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_gateway_controller_pod_identity_iam_policy_name"></a> [aws\_gateway\_controller\_pod\_identity\_iam\_policy\_name](#output\_aws\_gateway\_controller\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -127,6 +139,7 @@ No inputs.
 | <a name="output_aws_gateway_controller_pod_identity_iam_role_name"></a> [aws\_gateway\_controller\_pod\_identity\_iam\_role\_name](#output\_aws\_gateway\_controller\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_gateway_controller_pod_identity_iam_role_path"></a> [aws\_gateway\_controller\_pod\_identity\_iam\_role\_path](#output\_aws\_gateway\_controller\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_gateway_controller_pod_identity_iam_role_unique_id"></a> [aws\_gateway\_controller\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_gateway\_controller\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_lb_controller_pod_identity_associations"></a> [aws\_lb\_controller\_pod\_identity\_associations](#output\_aws\_lb\_controller\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_lb_controller_pod_identity_iam_policy_arn"></a> [aws\_lb\_controller\_pod\_identity\_iam\_policy\_arn](#output\_aws\_lb\_controller\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_lb_controller_pod_identity_iam_policy_id"></a> [aws\_lb\_controller\_pod\_identity\_iam\_policy\_id](#output\_aws\_lb\_controller\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_lb_controller_pod_identity_iam_policy_name"></a> [aws\_lb\_controller\_pod\_identity\_iam\_policy\_name](#output\_aws\_lb\_controller\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -134,6 +147,7 @@ No inputs.
 | <a name="output_aws_lb_controller_pod_identity_iam_role_name"></a> [aws\_lb\_controller\_pod\_identity\_iam\_role\_name](#output\_aws\_lb\_controller\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_lb_controller_pod_identity_iam_role_path"></a> [aws\_lb\_controller\_pod\_identity\_iam\_role\_path](#output\_aws\_lb\_controller\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_lb_controller_pod_identity_iam_role_unique_id"></a> [aws\_lb\_controller\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_lb\_controller\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_lb_controller_targetgroup_binding_only_pod_identity_associations"></a> [aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_associations](#output\_aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_lb_controller_targetgroup_binding_only_pod_identity_iam_policy_arn"></a> [aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_policy\_arn](#output\_aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_lb_controller_targetgroup_binding_only_pod_identity_iam_policy_id"></a> [aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_policy\_id](#output\_aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_lb_controller_targetgroup_binding_only_pod_identity_iam_policy_name"></a> [aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_policy\_name](#output\_aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -141,6 +155,7 @@ No inputs.
 | <a name="output_aws_lb_controller_targetgroup_binding_only_pod_identity_iam_role_name"></a> [aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_role\_name](#output\_aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_lb_controller_targetgroup_binding_only_pod_identity_iam_role_path"></a> [aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_role\_path](#output\_aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_lb_controller_targetgroup_binding_only_pod_identity_iam_role_unique_id"></a> [aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_lb\_controller\_targetgroup\_binding\_only\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_node_termination_handler_pod_identity_associations"></a> [aws\_node\_termination\_handler\_pod\_identity\_associations](#output\_aws\_node\_termination\_handler\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_node_termination_handler_pod_identity_iam_policy_arn"></a> [aws\_node\_termination\_handler\_pod\_identity\_iam\_policy\_arn](#output\_aws\_node\_termination\_handler\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_node_termination_handler_pod_identity_iam_policy_id"></a> [aws\_node\_termination\_handler\_pod\_identity\_iam\_policy\_id](#output\_aws\_node\_termination\_handler\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_node_termination_handler_pod_identity_iam_policy_name"></a> [aws\_node\_termination\_handler\_pod\_identity\_iam\_policy\_name](#output\_aws\_node\_termination\_handler\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -148,6 +163,7 @@ No inputs.
 | <a name="output_aws_node_termination_handler_pod_identity_iam_role_name"></a> [aws\_node\_termination\_handler\_pod\_identity\_iam\_role\_name](#output\_aws\_node\_termination\_handler\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_node_termination_handler_pod_identity_iam_role_path"></a> [aws\_node\_termination\_handler\_pod\_identity\_iam\_role\_path](#output\_aws\_node\_termination\_handler\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_node_termination_handler_pod_identity_iam_role_unique_id"></a> [aws\_node\_termination\_handler\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_node\_termination\_handler\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_privateca_issuer_pod_identity_associations"></a> [aws\_privateca\_issuer\_pod\_identity\_associations](#output\_aws\_privateca\_issuer\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_privateca_issuer_pod_identity_iam_policy_arn"></a> [aws\_privateca\_issuer\_pod\_identity\_iam\_policy\_arn](#output\_aws\_privateca\_issuer\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_privateca_issuer_pod_identity_iam_policy_id"></a> [aws\_privateca\_issuer\_pod\_identity\_iam\_policy\_id](#output\_aws\_privateca\_issuer\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_privateca_issuer_pod_identity_iam_policy_name"></a> [aws\_privateca\_issuer\_pod\_identity\_iam\_policy\_name](#output\_aws\_privateca\_issuer\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -155,6 +171,7 @@ No inputs.
 | <a name="output_aws_privateca_issuer_pod_identity_iam_role_name"></a> [aws\_privateca\_issuer\_pod\_identity\_iam\_role\_name](#output\_aws\_privateca\_issuer\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_privateca_issuer_pod_identity_iam_role_path"></a> [aws\_privateca\_issuer\_pod\_identity\_iam\_role\_path](#output\_aws\_privateca\_issuer\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_privateca_issuer_pod_identity_iam_role_unique_id"></a> [aws\_privateca\_issuer\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_privateca\_issuer\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_vpc_cni_ipv4_pod_identity_associations"></a> [aws\_vpc\_cni\_ipv4\_pod\_identity\_associations](#output\_aws\_vpc\_cni\_ipv4\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_vpc_cni_ipv4_pod_identity_iam_policy_arn"></a> [aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_policy\_arn](#output\_aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_vpc_cni_ipv4_pod_identity_iam_policy_id"></a> [aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_policy\_id](#output\_aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_vpc_cni_ipv4_pod_identity_iam_policy_name"></a> [aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_policy\_name](#output\_aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -162,6 +179,7 @@ No inputs.
 | <a name="output_aws_vpc_cni_ipv4_pod_identity_iam_role_name"></a> [aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_role\_name](#output\_aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_vpc_cni_ipv4_pod_identity_iam_role_path"></a> [aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_role\_path](#output\_aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_vpc_cni_ipv4_pod_identity_iam_role_unique_id"></a> [aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_vpc\_cni\_ipv4\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_aws_vpc_cni_ipv6_pod_identity_associations"></a> [aws\_vpc\_cni\_ipv6\_pod\_identity\_associations](#output\_aws\_vpc\_cni\_ipv6\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_aws_vpc_cni_ipv6_pod_identity_iam_policy_arn"></a> [aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_policy\_arn](#output\_aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_aws_vpc_cni_ipv6_pod_identity_iam_policy_id"></a> [aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_policy\_id](#output\_aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_aws_vpc_cni_ipv6_pod_identity_iam_policy_name"></a> [aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_policy\_name](#output\_aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -169,6 +187,7 @@ No inputs.
 | <a name="output_aws_vpc_cni_ipv6_pod_identity_iam_role_name"></a> [aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_role\_name](#output\_aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_aws_vpc_cni_ipv6_pod_identity_iam_role_path"></a> [aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_role\_path](#output\_aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_aws_vpc_cni_ipv6_pod_identity_iam_role_unique_id"></a> [aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_role\_unique\_id](#output\_aws\_vpc\_cni\_ipv6\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_cert_manager_pod_identity_associations"></a> [cert\_manager\_pod\_identity\_associations](#output\_cert\_manager\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_cert_manager_pod_identity_iam_policy_arn"></a> [cert\_manager\_pod\_identity\_iam\_policy\_arn](#output\_cert\_manager\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_cert_manager_pod_identity_iam_policy_id"></a> [cert\_manager\_pod\_identity\_iam\_policy\_id](#output\_cert\_manager\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_cert_manager_pod_identity_iam_policy_name"></a> [cert\_manager\_pod\_identity\_iam\_policy\_name](#output\_cert\_manager\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -176,6 +195,7 @@ No inputs.
 | <a name="output_cert_manager_pod_identity_iam_role_name"></a> [cert\_manager\_pod\_identity\_iam\_role\_name](#output\_cert\_manager\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_cert_manager_pod_identity_iam_role_path"></a> [cert\_manager\_pod\_identity\_iam\_role\_path](#output\_cert\_manager\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_cert_manager_pod_identity_iam_role_unique_id"></a> [cert\_manager\_pod\_identity\_iam\_role\_unique\_id](#output\_cert\_manager\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_cluster_autoscaler_pod_identity_associations"></a> [cluster\_autoscaler\_pod\_identity\_associations](#output\_cluster\_autoscaler\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_cluster_autoscaler_pod_identity_iam_policy_arn"></a> [cluster\_autoscaler\_pod\_identity\_iam\_policy\_arn](#output\_cluster\_autoscaler\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_cluster_autoscaler_pod_identity_iam_policy_id"></a> [cluster\_autoscaler\_pod\_identity\_iam\_policy\_id](#output\_cluster\_autoscaler\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_cluster_autoscaler_pod_identity_iam_policy_name"></a> [cluster\_autoscaler\_pod\_identity\_iam\_policy\_name](#output\_cluster\_autoscaler\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -183,6 +203,7 @@ No inputs.
 | <a name="output_cluster_autoscaler_pod_identity_iam_role_name"></a> [cluster\_autoscaler\_pod\_identity\_iam\_role\_name](#output\_cluster\_autoscaler\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_cluster_autoscaler_pod_identity_iam_role_path"></a> [cluster\_autoscaler\_pod\_identity\_iam\_role\_path](#output\_cluster\_autoscaler\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_cluster_autoscaler_pod_identity_iam_role_unique_id"></a> [cluster\_autoscaler\_pod\_identity\_iam\_role\_unique\_id](#output\_cluster\_autoscaler\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_custom_pod_identity_associations"></a> [custom\_pod\_identity\_associations](#output\_custom\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_custom_pod_identity_iam_policy_arn"></a> [custom\_pod\_identity\_iam\_policy\_arn](#output\_custom\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_custom_pod_identity_iam_policy_id"></a> [custom\_pod\_identity\_iam\_policy\_id](#output\_custom\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_custom_pod_identity_iam_policy_name"></a> [custom\_pod\_identity\_iam\_policy\_name](#output\_custom\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -190,6 +211,7 @@ No inputs.
 | <a name="output_custom_pod_identity_iam_role_name"></a> [custom\_pod\_identity\_iam\_role\_name](#output\_custom\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_custom_pod_identity_iam_role_path"></a> [custom\_pod\_identity\_iam\_role\_path](#output\_custom\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_custom_pod_identity_iam_role_unique_id"></a> [custom\_pod\_identity\_iam\_role\_unique\_id](#output\_custom\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_external_dns_pod_identity_associations"></a> [external\_dns\_pod\_identity\_associations](#output\_external\_dns\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_external_dns_pod_identity_iam_policy_arn"></a> [external\_dns\_pod\_identity\_iam\_policy\_arn](#output\_external\_dns\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_external_dns_pod_identity_iam_policy_id"></a> [external\_dns\_pod\_identity\_iam\_policy\_id](#output\_external\_dns\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_external_dns_pod_identity_iam_policy_name"></a> [external\_dns\_pod\_identity\_iam\_policy\_name](#output\_external\_dns\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -197,6 +219,7 @@ No inputs.
 | <a name="output_external_dns_pod_identity_iam_role_name"></a> [external\_dns\_pod\_identity\_iam\_role\_name](#output\_external\_dns\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_external_dns_pod_identity_iam_role_path"></a> [external\_dns\_pod\_identity\_iam\_role\_path](#output\_external\_dns\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_external_dns_pod_identity_iam_role_unique_id"></a> [external\_dns\_pod\_identity\_iam\_role\_unique\_id](#output\_external\_dns\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_external_secrets_pod_identity_associations"></a> [external\_secrets\_pod\_identity\_associations](#output\_external\_secrets\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_external_secrets_pod_identity_iam_policy_arn"></a> [external\_secrets\_pod\_identity\_iam\_policy\_arn](#output\_external\_secrets\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_external_secrets_pod_identity_iam_policy_id"></a> [external\_secrets\_pod\_identity\_iam\_policy\_id](#output\_external\_secrets\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_external_secrets_pod_identity_iam_policy_name"></a> [external\_secrets\_pod\_identity\_iam\_policy\_name](#output\_external\_secrets\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -204,6 +227,7 @@ No inputs.
 | <a name="output_external_secrets_pod_identity_iam_role_name"></a> [external\_secrets\_pod\_identity\_iam\_role\_name](#output\_external\_secrets\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_external_secrets_pod_identity_iam_role_path"></a> [external\_secrets\_pod\_identity\_iam\_role\_path](#output\_external\_secrets\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_external_secrets_pod_identity_iam_role_unique_id"></a> [external\_secrets\_pod\_identity\_iam\_role\_unique\_id](#output\_external\_secrets\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_mountpoint_s3_csi_pod_identity_associations"></a> [mountpoint\_s3\_csi\_pod\_identity\_associations](#output\_mountpoint\_s3\_csi\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_mountpoint_s3_csi_pod_identity_iam_policy_arn"></a> [mountpoint\_s3\_csi\_pod\_identity\_iam\_policy\_arn](#output\_mountpoint\_s3\_csi\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_mountpoint_s3_csi_pod_identity_iam_policy_id"></a> [mountpoint\_s3\_csi\_pod\_identity\_iam\_policy\_id](#output\_mountpoint\_s3\_csi\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_mountpoint_s3_csi_pod_identity_iam_policy_name"></a> [mountpoint\_s3\_csi\_pod\_identity\_iam\_policy\_name](#output\_mountpoint\_s3\_csi\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |
@@ -211,6 +235,7 @@ No inputs.
 | <a name="output_mountpoint_s3_csi_pod_identity_iam_role_name"></a> [mountpoint\_s3\_csi\_pod\_identity\_iam\_role\_name](#output\_mountpoint\_s3\_csi\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_mountpoint_s3_csi_pod_identity_iam_role_path"></a> [mountpoint\_s3\_csi\_pod\_identity\_iam\_role\_path](#output\_mountpoint\_s3\_csi\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_mountpoint_s3_csi_pod_identity_iam_role_unique_id"></a> [mountpoint\_s3\_csi\_pod\_identity\_iam\_role\_unique\_id](#output\_mountpoint\_s3\_csi\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_velero_pod_identity_associations"></a> [velero\_pod\_identity\_associations](#output\_velero\_pod\_identity\_associations) | Map of Pod Identity associations created |
 | <a name="output_velero_pod_identity_iam_policy_arn"></a> [velero\_pod\_identity\_iam\_policy\_arn](#output\_velero\_pod\_identity\_iam\_policy\_arn) | The ARN assigned by AWS to this policy |
 | <a name="output_velero_pod_identity_iam_policy_id"></a> [velero\_pod\_identity\_iam\_policy\_id](#output\_velero\_pod\_identity\_iam\_policy\_id) | ID of IAM policy |
 | <a name="output_velero_pod_identity_iam_policy_name"></a> [velero\_pod\_identity\_iam\_policy\_name](#output\_velero\_pod\_identity\_iam\_policy\_name) | Name of IAM policy |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,9 +2,14 @@ provider "aws" {
   region = local.region
 }
 
+data "aws_availability_zones" "available" {}
+
 locals {
   region = "eu-west-1"
-  name   = "eks-pod-identity-ex-${basename(path.cwd)}"
+  name   = "pod-id-ex-${basename(path.cwd)}"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 
   tags = {
     Name       = local.name
@@ -31,6 +36,19 @@ module "custom_pod_identity" {
     additional           = aws_iam_policy.additional.arn
   }
 
+  associations = {
+    ex-one = {
+      cluster_name    = module.eks_one.cluster_name
+      namespace       = "custom"
+      service_account = "custom"
+    }
+    ex-two = {
+      cluster_name    = module.eks_two.cluster_name
+      namespace       = "custom"
+      service_account = "custom"
+    }
+  }
+
   tags = local.tags
 }
 
@@ -40,6 +58,21 @@ module "aws_gateway_controller_pod_identity" {
   name = "aws-gateway-controller"
 
   attach_aws_gateway_controller_policy = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "aws-application-networking-system"
+    service_account = "gateway-api-controller"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -52,6 +85,21 @@ module "cert_manager_pod_identity" {
   attach_cert_manager_policy    = true
   cert_manager_hosted_zone_arns = ["arn:aws:route53:::hostedzone/IClearlyMadeThisUp"]
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "cert-manager"
+    service_account = "cert-manager"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -61,6 +109,21 @@ module "aws_cloudwatch_observability_pod_identity" {
   name = "aws-cloudwatch-observability"
 
   attach_aws_cloudwatch_observability_policy = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "amazon-cloudwatch"
+    service_account = "cloudwatch-agent"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -73,6 +136,21 @@ module "cluster_autoscaler_pod_identity" {
   attach_cluster_autoscaler_policy = true
   cluster_autoscaler_cluster_names = ["foo"]
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "cluster-autoscaler-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -84,6 +162,21 @@ module "aws_ebs_csi_pod_identity" {
   attach_aws_ebs_csi_policy = true
   aws_ebs_csi_kms_arns      = ["arn:aws:kms:*:*:key/1234abcd-12ab-34cd-56ef-1234567890ab"]
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "ebs-csi-controller-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -93,6 +186,21 @@ module "aws_efs_csi_pod_identity" {
   name = "aws-efs-csi"
 
   attach_aws_efs_csi_policy = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "efs-csi-controller-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -104,6 +212,21 @@ module "external_dns_pod_identity" {
 
   attach_external_dns_policy    = true
   external_dns_hosted_zone_arns = ["arn:aws:route53:::hostedzone/IClearlyMadeThisUp"]
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "external-dns"
+    service_account = "external-dns-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -119,6 +242,21 @@ module "external_secrets_pod_identity" {
   external_secrets_kms_key_arns         = ["arn:aws:kms:*:*:key/1234abcd-12ab-34cd-56ef-1234567890ab"]
   external_secrets_create_permission    = true
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "external-secrets"
+    service_account = "external-secrets-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -130,6 +268,21 @@ module "aws_fsx_lustre_csi_pod_identity" {
   attach_aws_fsx_lustre_csi_policy     = true
   aws_fsx_lustre_csi_service_role_arns = ["arn:aws:iam::*:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*"]
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "fsx-csi-controller-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -139,6 +292,21 @@ module "aws_lb_controller_pod_identity" {
   name = "aws-lbc"
 
   attach_aws_lb_controller_policy = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "aws-load-balancer-controller-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -151,6 +319,21 @@ module "aws_lb_controller_targetgroup_binding_only_pod_identity" {
   attach_aws_lb_controller_targetgroup_binding_only_policy = true
   aws_lb_controller_targetgroup_arns                       = ["arn:aws:elasticloadbalancing:*:*:targetgroup/foo/bar"]
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "aws-load-balancer-controller-tgb-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -160,6 +343,21 @@ module "aws_appmesh_controller_pod_identity" {
   name = "aws-appmesh-controller"
 
   attach_aws_appmesh_controller_policy = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "appmesh-system"
+    service_account = "appmesh-controller"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -171,6 +369,21 @@ module "aws_appmesh_envoy_proxy_pod_identity" {
 
   attach_aws_appmesh_envoy_proxy_policy = true
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "appmesh-system"
+    service_account = "envoy-proxy"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -181,6 +394,21 @@ module "amazon_managed_service_prometheus_pod_identity" {
 
   attach_amazon_managed_service_prometheus_policy  = true
   amazon_managed_service_prometheus_workspace_arns = ["arn:aws:prometheus:*:*:workspace/foo"]
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "prometheus"
+    service_account = "prometheus"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -194,6 +422,21 @@ module "mountpoint_s3_csi_pod_identity" {
   mountpoint_s3_csi_bucket_arns      = ["arn:aws:s3:::mountpoint-s3"]
   mountpoint_s3_csi_bucket_path_arns = ["arn:aws:s3:::mountpoint-s3/example/*"]
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "s3-csi-driver-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -205,6 +448,21 @@ module "aws_node_termination_handler_pod_identity" {
   attach_aws_node_termination_handler_policy  = true
   aws_node_termination_handler_sqs_queue_arns = ["arn:aws:sqs:*:*:eks-node-termination-handler"]
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "aws-node-termination-handler"
+    service_account = "aws-node-termination-handler-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -215,6 +473,21 @@ module "aws_privateca_issuer_pod_identity" {
 
   attach_aws_privateca_issuer_policy = true
   aws_privateca_issuer_acmca_arns    = ["arn:aws:acm-pca:*:*:certificate-authority/foo"]
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "cert-manager"
+    service_account = "aws-privateca-issuer-sa"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -228,6 +501,21 @@ module "velero_pod_identity" {
   velero_s3_bucket_arns      = ["arn:aws:s3:::velero-backups"]
   velero_s3_bucket_path_arns = ["arn:aws:s3:::velero-backups/example/*"]
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "velero"
+    service_account = "velero-server"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -239,6 +527,21 @@ module "aws_vpc_cni_ipv4_pod_identity" {
   attach_aws_vpc_cni_policy = true
   aws_vpc_cni_enable_ipv4   = true
 
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "aws-node"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
+
   tags = local.tags
 }
 
@@ -249,6 +552,21 @@ module "aws_vpc_cni_ipv6_pod_identity" {
 
   attach_aws_vpc_cni_policy = true
   aws_vpc_cni_enable_ipv6   = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = "kube-system"
+    service_account = "aws-node-ipv6"
+  }
+
+  associations = {
+    ex-one = {
+      cluster_name = module.eks_one.cluster_name
+    }
+    ex-two = {
+      cluster_name = module.eks_two.cluster_name
+    }
+  }
 
   tags = local.tags
 }
@@ -297,4 +615,43 @@ data "aws_iam_policy_document" "override" {
     actions   = ["s3:*"]
     resources = ["*"]
   }
+}
+
+module "eks_one" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name = "${local.name}-one"
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  tags = local.tags
+}
+
+module "eks_two" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name = "${local.name}-two"
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  tags = local.tags
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  azs             = local.azs
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
+
+  enable_nat_gateway = false
+
+  tags = local.tags
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -37,6 +37,11 @@ output "custom_pod_identity_iam_policy_id" {
   value       = module.custom_pod_identity.iam_policy_id
 }
 
+output "custom_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.custom_pod_identity.associations
+}
+
 ################################################################################
 # AWS Gateway Controller
 ################################################################################
@@ -74,6 +79,11 @@ output "aws_gateway_controller_pod_identity_iam_policy_name" {
 output "aws_gateway_controller_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.aws_gateway_controller_pod_identity.iam_policy_id
+}
+
+output "aws_gateway_controller_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_gateway_controller_pod_identity.associations
 }
 
 ################################################################################
@@ -115,6 +125,11 @@ output "cert_manager_pod_identity_iam_policy_id" {
   value       = module.cert_manager_pod_identity.iam_policy_id
 }
 
+output "cert_manager_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.cert_manager_pod_identity.associations
+}
+
 ################################################################################
 # AWS CloudWatch Observability
 ################################################################################
@@ -152,6 +167,11 @@ output "aws_cloudwatch_observability_pod_identity_iam_policy_name" {
 output "aws_cloudwatch_observability_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.aws_cloudwatch_observability_pod_identity.iam_policy_id
+}
+
+output "aws_cloudwatch_observability_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_cloudwatch_observability_pod_identity.associations
 }
 
 ################################################################################
@@ -193,6 +213,11 @@ output "cluster_autoscaler_pod_identity_iam_policy_id" {
   value       = module.cluster_autoscaler_pod_identity.iam_policy_id
 }
 
+output "cluster_autoscaler_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.cluster_autoscaler_pod_identity.associations
+}
+
 ################################################################################
 # AWS EBS CSI Driver
 ################################################################################
@@ -230,6 +255,11 @@ output "aws_ebs_csi_pod_identity_iam_policy_name" {
 output "aws_ebs_csi_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.aws_ebs_csi_pod_identity.iam_policy_id
+}
+
+output "aws_ebs_csi_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_ebs_csi_pod_identity.associations
 }
 
 ################################################################################
@@ -271,6 +301,11 @@ output "aws_efs_csi_pod_identity_iam_policy_id" {
   value       = module.aws_efs_csi_pod_identity.iam_policy_id
 }
 
+output "aws_efs_csi_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_efs_csi_pod_identity.associations
+}
+
 ################################################################################
 # External-DNS
 ################################################################################
@@ -308,6 +343,11 @@ output "external_dns_pod_identity_iam_policy_name" {
 output "external_dns_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.external_dns_pod_identity.iam_policy_id
+}
+
+output "external_dns_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.external_dns_pod_identity.associations
 }
 
 ################################################################################
@@ -349,6 +389,11 @@ output "external_secrets_pod_identity_iam_policy_id" {
   value       = module.external_secrets_pod_identity.iam_policy_id
 }
 
+output "external_secrets_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.external_secrets_pod_identity.associations
+}
+
 ################################################################################
 # AWS FSx for Lustre CSI Driver
 ################################################################################
@@ -386,6 +431,11 @@ output "aws_fsx_lustre_csi_pod_identity_iam_policy_name" {
 output "aws_fsx_lustre_csi_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.aws_fsx_lustre_csi_pod_identity.iam_policy_id
+}
+
+output "aws_fsx_lustre_csi_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_fsx_lustre_csi_pod_identity.associations
 }
 
 ################################################################################
@@ -427,6 +477,11 @@ output "aws_lb_controller_pod_identity_iam_policy_id" {
   value       = module.aws_lb_controller_pod_identity.iam_policy_id
 }
 
+output "aws_lb_controller_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_lb_controller_pod_identity.associations
+}
+
 ################################################################################
 # AWS Load Balancer Controller TargetGroup Binding Only
 ################################################################################
@@ -464,6 +519,11 @@ output "aws_lb_controller_targetgroup_binding_only_pod_identity_iam_policy_name"
 output "aws_lb_controller_targetgroup_binding_only_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.aws_lb_controller_targetgroup_binding_only_pod_identity.iam_policy_id
+}
+
+output "aws_lb_controller_targetgroup_binding_only_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_lb_controller_targetgroup_binding_only_pod_identity.associations
 }
 
 ################################################################################
@@ -505,6 +565,11 @@ output "aws_appmesh_controller_pod_identity_iam_policy_id" {
   value       = module.aws_appmesh_controller_pod_identity.iam_policy_id
 }
 
+output "aws_appmesh_controller_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_appmesh_controller_pod_identity.associations
+}
+
 ################################################################################
 # AWS AppMesh Envoy Proxy
 ################################################################################
@@ -542,6 +607,11 @@ output "aws_appmesh_envoy_proxy_pod_identity_iam_policy_name" {
 output "aws_appmesh_envoy_proxy_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.aws_appmesh_envoy_proxy_pod_identity.iam_policy_id
+}
+
+output "aws_appmesh_envoy_proxy_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_appmesh_envoy_proxy_pod_identity.associations
 }
 
 ################################################################################
@@ -583,6 +653,11 @@ output "amazon_managed_service_prometheus_pod_identity_iam_policy_id" {
   value       = module.amazon_managed_service_prometheus_pod_identity.iam_policy_id
 }
 
+output "amazon_managed_service_prometheus_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.amazon_managed_service_prometheus_pod_identity.associations
+}
+
 ################################################################################
 # Mountpoint S3 CSI Driver
 ################################################################################
@@ -620,6 +695,11 @@ output "mountpoint_s3_csi_pod_identity_iam_policy_name" {
 output "mountpoint_s3_csi_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.mountpoint_s3_csi_pod_identity.iam_policy_id
+}
+
+output "mountpoint_s3_csi_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.mountpoint_s3_csi_pod_identity.associations
 }
 
 ################################################################################
@@ -661,6 +741,11 @@ output "aws_node_termination_handler_pod_identity_iam_policy_id" {
   value       = module.aws_node_termination_handler_pod_identity.iam_policy_id
 }
 
+output "aws_node_termination_handler_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_node_termination_handler_pod_identity.associations
+}
+
 ################################################################################
 # AWS Private CA Issuer
 ################################################################################
@@ -698,6 +783,11 @@ output "aws_privateca_issuer_pod_identity_iam_policy_name" {
 output "aws_privateca_issuer_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.aws_privateca_issuer_pod_identity.iam_policy_id
+}
+
+output "aws_privateca_issuer_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_privateca_issuer_pod_identity.associations
 }
 
 ################################################################################
@@ -739,6 +829,11 @@ output "velero_pod_identity_iam_policy_id" {
   value       = module.velero_pod_identity.iam_policy_id
 }
 
+output "velero_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.velero_pod_identity.associations
+}
+
 ################################################################################
 # AWS VPC CNI IPv4
 ################################################################################
@@ -778,6 +873,11 @@ output "aws_vpc_cni_ipv4_pod_identity_iam_policy_id" {
   value       = module.aws_vpc_cni_ipv4_pod_identity.iam_policy_id
 }
 
+output "aws_vpc_cni_ipv4_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_vpc_cni_ipv4_pod_identity.associations
+}
+
 ################################################################################
 # AWS VPC CNI IPv6
 ################################################################################
@@ -815,4 +915,9 @@ output "aws_vpc_cni_ipv6_pod_identity_iam_policy_name" {
 output "aws_vpc_cni_ipv6_pod_identity_iam_policy_id" {
   description = "ID of IAM policy"
   value       = module.aws_vpc_cni_ipv6_pod_identity.iam_policy_id
+}
+
+output "aws_vpc_cni_ipv6_pod_identity_associations" {
+  description = "Map of Pod Identity associations created"
+  value       = module.aws_vpc_cni_ipv6_pod_identity.associations
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -169,3 +169,18 @@ resource "aws_iam_role_policy_attachment" "custom" {
   role       = aws_iam_role.this[0].name
   policy_arn = aws_iam_policy.custom[0].arn
 }
+
+################################################################################
+# Pod Identity Association
+################################################################################
+
+resource "aws_eks_pod_identity_association" "this" {
+  for_each = { for k, v in var.associations : k => v if var.create }
+
+  cluster_name    = try(each.value.cluster_name, var.association_defaults.cluster_name)
+  namespace       = try(each.value.namespace, var.association_defaults.namespace)
+  service_account = try(each.value.service_account, var.association_defaults.service_account)
+  role_arn        = aws_iam_role.this[0].arn
+
+  tags = merge(var.tags, try(each.value.tags, var.association_defaults.tags, {}))
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -81,7 +81,7 @@ output "iam_policy_name" {
 }
 
 output "iam_policy_id" {
-  description = " The policy's ID"
+  description = "The policy's ID"
   value = try(
     aws_iam_policy.amazon_managed_service_prometheus[0].policy_id,
     aws_iam_policy.appmesh_controller[0].policy_id,
@@ -104,4 +104,13 @@ output "iam_policy_id" {
     aws_iam_policy.custom[0].policy_id,
     null,
   )
+}
+
+################################################################################
+# Pod Identity Association
+################################################################################
+
+output "associations" {
+  description = "Map of Pod Identity associations created"
+  value       = aws_eks_pod_identity_association.this
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,22 @@ variable "additional_policy_arns" {
 }
 
 ################################################################################
+# Pod Identity Association
+################################################################################
+
+variable "association_defaults" {
+  description = "Default values used across all Pod Identity associations created unless a more specific value is provided"
+  type        = map(string)
+  default     = {}
+}
+
+variable "associations" {
+  description = "Map of Pod Identity associations to be created (map of maps)"
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # Policies
 ################################################################################
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -8,6 +8,8 @@ module "wrapper" {
   amazon_managed_service_prometheus_workspace_arns         = try(each.value.amazon_managed_service_prometheus_workspace_arns, var.defaults.amazon_managed_service_prometheus_workspace_arns, [])
   appmesh_controller_policy_name                           = try(each.value.appmesh_controller_policy_name, var.defaults.appmesh_controller_policy_name, null)
   appmesh_envoy_proxy_policy_name                          = try(each.value.appmesh_envoy_proxy_policy_name, var.defaults.appmesh_envoy_proxy_policy_name, null)
+  association_defaults                                     = try(each.value.association_defaults, var.defaults.association_defaults, {})
+  associations                                             = try(each.value.associations, var.defaults.associations, {})
   attach_amazon_managed_service_prometheus_policy          = try(each.value.attach_amazon_managed_service_prometheus_policy, var.defaults.attach_amazon_managed_service_prometheus_policy, false)
   attach_aws_appmesh_controller_policy                     = try(each.value.attach_aws_appmesh_controller_policy, var.defaults.attach_aws_appmesh_controller_policy, false)
   attach_aws_appmesh_envoy_proxy_policy                    = try(each.value.attach_aws_appmesh_envoy_proxy_policy, var.defaults.attach_aws_appmesh_envoy_proxy_policy, false)


### PR DESCRIPTION
## Description
- Add support for creating pod identity associations

I still don't know where the best place to put this resource is, but I bet it will end up in multiple locations based on how users want to manage the associations (i.e. - should it be with the role, should it be with the cluster, somewhere in-between???)

## Motivation and Context
- Resolves #3

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
