### PR TITLE
docs: Update link to recommended policy for `aws_gateway_controller`

### DIFF
--- a/aws_gateway_controller.tf
+++ b/aws_gateway_controller.tf
@@ -2,7 +2,7 @@
 # AWS Gateway Controller Policy
 ################################################################################
 
-# https://github.com/aws/aws-application-networking-k8s/blob/main/examples/recommended-inline-policy.json
+# https://github.com/aws/aws-application-networking-k8s/blob/main/files/controller-installation/recommended-inline-policy.json
 
 data "aws_iam_policy_document" "aws_gateway_controller" {
   count = var.create && var.attach_aws_gateway_controller_policy ? 1 : 0


### PR DESCRIPTION
## Description

Update link to recommended policy for aws_gateway_controller

## Motivation and Context

Previous link was expired

## Breaking Changes

No.

<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?

It's just a comment.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
