### PR TITLE
fix: TargetGroup Binding only policy requires policies for SecurityGroup

### DIFF
--- a/aws_lb_controller.tf
+++ b/aws_lb_controller.tf
@@ -302,6 +302,8 @@ data "aws_iam_policy_document" "lb_controller_targetgroup_only" {
       "ec2:DescribeVpcs",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeInstances",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:RevokeSecurityGroupIngress",
       "elasticloadbalancing:DescribeTargetGroups",
       "elasticloadbalancing:DescribeTargetHealth",
     ]


### PR DESCRIPTION
## Description
Added policies for TargetGroup Binding only policy to work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The latest version of AWS LBC requires some SecurityGroup operations. This fix adds the policies required for these operations. A similar fix can be found in IRSA module: https://github.com/terraform-aws-modules/terraform-aws-iam/pull/292

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
