### PR TITLE
fix: Ensure FSX IAM Policy Permits Updating File Systems

### DIFF
--- a/aws_fsx_lustre_csi.tf
+++ b/aws_fsx_lustre_csi.tf
@@ -37,6 +37,7 @@ data "aws_iam_policy_document" "fsx_lustre_csi" {
       "fsx:DeleteFileSystem",
       "fsx:DescribeFileSystems",
       "fsx:TagResource",
+      "fsx:UpdateFileSystem",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updates FSX IAM Policy to permit File System Updates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Aligns the policy provided with the recommended upstream.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
