### PR TITLE
fix: Add required S3 PutObjectTagging permission to IAM policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.0
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 - [Complete](https://github.com/terraform-aws-modules/terraform-aws-eks-pod-identity/tree/master/examples/complete)
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -581,7 +581,7 @@ No modules.
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
 | <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## License
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -14,7 +14,7 @@ $ terraform apply
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -243,6 +243,6 @@ No inputs.
 | <a name="output_velero_pod_identity_iam_role_name"></a> [velero\_pod\_identity\_iam\_role\_name](#output\_velero\_pod\_identity\_iam\_role\_name) | Name of IAM role |
 | <a name="output_velero_pod_identity_iam_role_path"></a> [velero\_pod\_identity\_iam\_role\_path](#output\_velero\_pod\_identity\_iam\_role\_path) | Path of IAM role |
 | <a name="output_velero_pod_identity_iam_role_unique_id"></a> [velero\_pod\_identity\_iam\_role\_unique\_id](#output\_velero\_pod\_identity\_iam\_role\_unique\_id) | Unique ID of IAM role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-eks-pod-identity/blob/master/LICENSE).

--- a/velero.tf
+++ b/velero.tf
@@ -30,6 +30,7 @@ data "aws_iam_policy_document" "velero" {
       "s3:GetObject",
       "s3:DeleteObject",
       "s3:PutObject",
+      "s3:PutObjectTagging",
       "s3:AbortMultipartUpload",
       "s3:ListMultipartUploadParts",
     ]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Adds required `s3:PutObjectTagging` permission to Velero IAM policy
- Updates and re-runs pre-commit hooks

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This matches the policy with the upstream `velero-plugin-for-aws` documentation and `iam-role-for-service-accounts-eks` policy.

Also see:
- `velero-plugin-for-aws` [Issue](https://github.com/vmware-tanzu/velero/issues/8062)/[PR](https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/218)
- `terraform-aws-iam` [Issue](https://github.com/terraform-aws-modules/terraform-aws-iam/issues/518)/[PR](https://github.com/terraform-aws-modules/terraform-aws-iam/pull/517)

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
