### PR TITLE
fix: Use dynamic partition value

### DIFF
--- a/aws_ebs_csi.tf
+++ b/aws_ebs_csi.tf
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   statement {
     actions   = ["ec2:CreateVolume"]
-    resources = ["arn:aws:ec2:*:*:volume/*"]
+    resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {
       test     = "StringLike"
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   statement {
     actions   = ["ec2:CreateVolume"]
-    resources = ["arn:aws:ec2:*:*:volume/*"]
+    resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {
       test     = "StringLike"
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "ebs_csi" {
 
   statement {
     actions   = ["ec2:CreateVolume"]
-    resources = ["arn:aws:ec2:*:*:snapshot/*"]
+    resources = ["arn:${local.partition}:ec2:*:*:snapshot/*"]
   }
 
   statement {


### PR DESCRIPTION
## Description
Replacing hardcoded `aws` partition with `local.partition`

## Motivation and Context
Solves the issue hen trying to deploy to gov-cloud accounts.

## Breaking Changes
None

## How Has This Been Tested?
Nope
