### PR TITLE
feat: Add `ec2:GetSecurityGroupsForVpc` for AWS LB Controller `v2.10.0`

### DIFF
--- a/aws_lb_controller.tf
+++ b/aws_lb_controller.tf
@@ -36,6 +36,7 @@ data "aws_iam_policy_document" "lb_controller" {
       "ec2:DescribeTags",
       "ec2:GetCoipPoolUsage",
       "ec2:DescribeCoipPools",
+      "ec2:GetSecurityGroupsForVpc",
       "elasticloadbalancing:DescribeLoadBalancers",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeListeners",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

ELB has updated their managed policy to include ec2:GetSecurityGroupsForVpc.

https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.10.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #24 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None


## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
