### PR TITLE
feat: Update policies for AWS LBC v2.11.0

### DIFF
--- a/aws_lb_controller.tf
+++ b/aws_lb_controller.tf
@@ -49,6 +49,7 @@ data "aws_iam_policy_document" "lb_controller" {
       "elasticloadbalancing:DescribeTags",
       "elasticloadbalancing:DescribeTrustStores",
       "elasticloadbalancing:DescribeListenerAttributes",
+      "elasticloadbalancing:DescribeCapacityReservation",
     ]
     resources = ["*"]
   }
@@ -209,6 +210,7 @@ data "aws_iam_policy_document" "lb_controller" {
       "elasticloadbalancing:ModifyTargetGroupAttributes",
       "elasticloadbalancing:DeleteTargetGroup",
       "elasticloadbalancing:ModifyListenerAttributes",
+      "elasticloadbalancing:ModifyCapacityReservation",
     ]
     resources = ["*"]
 


### PR DESCRIPTION
## Description
This pull request includes updates to the IAM policy document for the load balancer controller in the `aws_lb_controller.tf` file. The changes involve adding new permissions related to capacity reservations.

Changes to IAM policy document:

* Added `elasticloadbalancing:DescribeCapacityReservation` permission to the list of actions.
* Added `elasticloadbalancing:ModifyCapacityReservation` permission to the list of actions

## Motivation and Context
AWS LBC 2.11.0 needs extra few permissions for describing and modifying capacity reservation.
https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.11.0

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
