### PR TITLE
fix: Fix IAM policy for External Secrets

### DIFF
--- a/external_secrets.tf
+++ b/external_secrets.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "external_secrets" {
     for_each = length(var.external_secrets_secrets_manager_arns) > 0 ? [1] : []
 
     content {
-      actions   = ["secretsmanager:ListSecrets"]
+      actions   = ["secretsmanager:ListSecrets", "secretsmanager:BatchGetSecretValue"]
       resources = ["*"]
     }
   }
@@ -49,8 +49,7 @@ data "aws_iam_policy_document" "external_secrets" {
         "secretsmanager:GetResourcePolicy",
         "secretsmanager:GetSecretValue",
         "secretsmanager:DescribeSecret",
-        "secretsmanager:ListSecretVersionIds",
-        "secretsmanager:BatchGetSecretValue",
+        "secretsmanager:ListSecretVersionIds"
       ]
 
       resources = var.external_secrets_secrets_manager_arns


### PR DESCRIPTION
## Description
This pull request includes updates to the IAM policy document for external secrets in the `modules/iam-role-for-service-accounts-eks/policies.tf` file. The changes adjust the actions allowed for the secrets manager.

Changes to IAM policy document:

* Added the `secretsmanager:BatchGetSecretValue` action to the list of allowed actions in one statement.
* Removed the `secretsmanager:BatchGetSecretValue` action from another statement to avoid redundancy.

## Motivation and Context

Two weeks ago, the `0.12.1`  version was launched for external-secrets. The new version requires a new permission for the action  `BatchGetSecretValue`.

I opened this PR  https://github.com/terraform-aws-modules/terraform-aws-iam/pull/542  with the suggested changes from the external-secrets repo, and the proposed policy was not working as expected. After reviewing it and reporting it to external-secrets, they finally modified the documentation with a working policy (https://github.com/external-secrets/external-secrets/pull/4275).

The new policy has been tested and works properly with the latest version.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
