### PR TITLE
feat: Add `ec2:DescribeSubnets` policy to `aws-vpc-cni`

### DIFF
--- a/aws_vpc_cni.tf
+++ b/aws_vpc_cni.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "vpc_cni" {
         "ec2:DescribeTags",
         "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeInstanceTypes",
+        "ec2:DescribeSubnets",
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:UnassignPrivateIpAddresses",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This extends the existing policy for the `aws-vpc-cni` by adding `ec2:DescribeSubnets`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was a recent change to the upstream `aws-vpc-cni` policy requirements; now needing `ec2:DescribeSubnets` permission (https://github.com/aws/amazon-vpc-cni-k8s/pull/2992). I have added the permission to the ipv4 feature as was done upstream.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
