### PR TITLE
feat: Update IAM permissions for load balancer controller v2.12.0

### DIFF
--- a/aws_lb_controller.tf
+++ b/aws_lb_controller.tf
@@ -211,6 +211,7 @@ data "aws_iam_policy_document" "lb_controller" {
       "elasticloadbalancing:DeleteTargetGroup",
       "elasticloadbalancing:ModifyListenerAttributes",
       "elasticloadbalancing:ModifyCapacityReservation",
+      "elasticloadbalancing:ModifyIpPools"
     ]
     resources = ["*"]
 
@@ -262,6 +263,7 @@ data "aws_iam_policy_document" "lb_controller" {
       "elasticloadbalancing:AddListenerCertificates",
       "elasticloadbalancing:RemoveListenerCertificates",
       "elasticloadbalancing:ModifyRule",
+      "elasticloadbalancing:SetRulePriorities"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updated AWS Load Balancer Controller IAM Policy to v2.12.0 release [example](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.12.0/docs/install/iam_policy.json).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows the controller to use Public IPAM pools for public IPs. This change also includes an action that was added as a bugfix, see https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4039.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
