### PR TITLE
feat: Update AWS Load Balancer controller policy to match v2.13 of the upstream project

### DIFF
--- a/aws_lb_controller.tf
+++ b/aws_lb_controller.tf
@@ -37,6 +37,8 @@ data "aws_iam_policy_document" "lb_controller" {
       "ec2:GetCoipPoolUsage",
       "ec2:DescribeCoipPools",
       "ec2:GetSecurityGroupsForVpc",
+      "ec2:DescribeIpamPools",
+      "ec2:DescribeRouteTables",
       "elasticloadbalancing:DescribeLoadBalancers",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeListeners",
@@ -81,6 +83,12 @@ data "aws_iam_policy_document" "lb_controller" {
     actions = [
       "ec2:AuthorizeSecurityGroupIngress",
       "ec2:RevokeSecurityGroupIngress",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
       "ec2:CreateSecurityGroup",
     ]
     resources = ["*"]


### PR DESCRIPTION
Update IAM policy with [latest changes](https://github.com/kubernetes-sigs/aws-load-balancer-controller/commit/2f6ce5cfc51a28257cf2710873c437257d1ef605#diff-18d547fa3761f3fd92e3c94aced34137247a3ebd73b3f547491dffc10859b712)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
