### PR TITLE
fix: Update IAM policy for External Secrets 

### DIFF
--- a/external_secrets.tf
+++ b/external_secrets.tf
@@ -26,6 +26,7 @@ data "aws_iam_policy_document" "external_secrets" {
       actions = [
         "ssm:GetParameter",
         "ssm:GetParameters",
+        "ssm:GetParametersByPath"
       ]
 
       resources = var.external_secrets_ssm_parameter_arns


### PR DESCRIPTION

## fix: add ssm:GetParametersByPath to External Secrets policy

using external-secrets v0.16.2 with AWS SSM secret store and mapping parameter like `/my/path/` the operator suggests to add `ssm:GetParametersByPath` 

operator log
```
provider.parameterstore","msg":"GetParametersByPath: access denied. using fallback to describe parameters. It is recommended to add ssm:GetParametersByPath permissions"
```