### PR TITLE
feat: Add support to `ebs-csi` policy for volume clones

### DIFF
--- a/aws_ebs_csi.tf
+++ b/aws_ebs_csi.tf
@@ -29,6 +29,11 @@ data "aws_iam_policy_document" "ebs_csi" {
   }
 
   statement {
+    actions   = ["ec2:CopyVolumes"]
+    resources = ["arn:${local.partition}:ec2:*:*:volume/vol-*"]
+  }
+
+  statement {
     actions = ["ec2:CreateTags"]
 
     resources = [
@@ -42,6 +47,7 @@ data "aws_iam_policy_document" "ebs_csi" {
       values = [
         "CreateVolume",
         "CreateSnapshot",
+        "CopyVolumes",
       ]
     }
   }
@@ -56,7 +62,10 @@ data "aws_iam_policy_document" "ebs_csi" {
   }
 
   statement {
-    actions   = ["ec2:CreateVolume"]
+    actions = [
+      "ec2:CreateVolume",
+      "ec2:CopyVolumes",
+    ]
     resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {
@@ -67,7 +76,10 @@ data "aws_iam_policy_document" "ebs_csi" {
   }
 
   statement {
-    actions   = ["ec2:CreateVolume"]
+    actions = [
+      "ec2:CreateVolume",
+      "ec2:CopyVolumes",
+    ]
     resources = ["arn:${local.partition}:ec2:*:*:volume/*"]
 
     condition {


### PR DESCRIPTION
## Description
This PR updates the policy for the EBS CSI to accommodate the newly added support for volume clones

## Motivation and Context
Following the [v.1.51.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.51.0) release of the aws-esb-csi-driver, [support for creating instant, point-in-time copies of EBS volumes within the same Availability Zone](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2716) has been added.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
