### PR TITLE
feat: Add `wafv2:ListWebACLs` permission for ALB controller

### DIFF
--- a/aws_lb_controller.tf
+++ b/aws_lb_controller.tf
@@ -71,6 +71,7 @@ data "aws_iam_policy_document" "lb_controller" {
       "wafv2:GetWebACLForResource",
       "wafv2:AssociateWebACL",
       "wafv2:DisassociateWebACL",
+      "wafv2:ListWebACLs",
       "shield:GetSubscriptionState",
       "shield:DescribeProtection",
       "shield:CreateProtection",


### PR DESCRIPTION
## Description
The AWS Load Balancer Controller requires the `wafv2:ListWebACLs` permission to resolve WAF ACL names to ARNs when using the `wafv2-acl-name` annotation.

Without this permission, the controller cannot find the WAF ACL by name, resulting in ingress creation failures.

This change adds the missing permission to the IAM policy for the aws-load-balancer-controller service account.


## Motivation and Context
This change is required since AWS Load Balancer Controller v2.14+ supports referencing WAF ACLs by name via the `alb.ingress.kubernetes.io/wafv2-acl-name` annotation instead of requiring ARNs. This simplifies configuration management as WAF ACL names are static while ARNs can change across environments.

The controller needs `wafv2:ListWebACLs` permission to query the WAF API and resolve the ACL name to its ARN before associating it with the load balancer. This permission complements the existing `wafv2:GetWebACL`, `wafv2:AssociateWebACL`, and `wafv2:DisassociateWebACL` permissions already present in the policy.

## Breaking Changes
No breaking changes. This is an additive change that expands the existing WAFv2 permissions to enable name-based WAF ACL references.


## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Deployed AWS Load Balancer Controller with this policy in a live EKS cluster
- Verified ingress resources with `wafv2-acl-name` annotations successfully resolve and associate WAF ACLs
- Confirmed no permission errors in controller logs
- [x] I have executed `pre-commit run -a` on my pull request
