### PR TITLE
fix: Replace deprecated `name` attribute with current `region` attribute to remove warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ data "aws_region" "current" {
 locals {
   partition  = try(data.aws_partition.current[0].partition, null)
   account_id = try(data.aws_caller_identity.current[0].account_id, null)
-  region     = try(data.aws_region.current[0].name, null)
+  region     = try(data.aws_region.current[0].region, null)
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Replace deprecated `name` attribute with current `region` attribute to remove warning

## Motivation and Context
- Remove warnings for deprecated attribute

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
