### PR TITLE
fix: Use empty strings for metadata default values to avoid template errors

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,9 +13,9 @@ data "aws_region" "current" {
 }
 
 locals {
-  partition  = try(data.aws_partition.current[0].partition, null)
-  account_id = try(data.aws_caller_identity.current[0].account_id, null)
-  region     = try(data.aws_region.current[0].region, null)
+  partition  = try(data.aws_partition.current[0].partition, "aws")
+  account_id = try(data.aws_caller_identity.current[0].account_id, "")
+  region     = try(data.aws_region.current[0].region, "")
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Use empty strings for metadata default values to avoid template errors

## Motivation and Context
- Resolves #50

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
