### PR TITLE
feat: Add `ListTagsForResource` to `external-dns` policy

### DIFF
--- a/external_dns.tf
+++ b/external_dns.tf
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "external_dns" {
       "route53:ListHostedZones",
       "route53:ListResourceRecordSets",
       "route53:ListTagsForResource",
+      "route53:ListTagsForResources",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
The additional IAM permission was first discussed in this Github issue: https://github.com/kubernetes-sigs/external-dns/issues/1019, which was implemented and the `external-dns` documentation was updated: https://github.com/tico24/external-dns/blob/master/docs/tutorials/aws.md

I left the earlier `ListTagsForResource` as-is since I think earlier versions of `external-dns` might still need it.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
