### PR TITLE
feat: Grant Velero permissions to restore encrypted EBS snapshots.

### DIFF
--- a/velero.tf
+++ b/velero.tf
@@ -55,6 +55,11 @@ data "aws_iam_policy_document" "velero" {
         "kms:ReEncrypt*",
         "kms:GenerateDataKey*",
         "kms:DescribeKey",
+        "kms:CreateGrant",
+        "kms:ListGrants",
+        "kms:RevokeGrant",
+        "kms:RetireGrant",
+        "kms:ListRetirableGrants",
       ]
 
       resources = var.velero_kms_arns


### PR DESCRIPTION
## Description
Grant Velero permissions to restore encrypted EBS snapshots.

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-eks-pod-identity/issues/43#issuecomment-3450830735
and 
https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/9854632fd70ff1e5d9ffbadcfa45a9b90e6f9942/README.md#kms-encryption-for-volume-restoration

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
