### PR TITLE
feat: Add missing EBS CSI driver IAM permissions

### DIFF
--- a/aws_ebs_csi.tf
+++ b/aws_ebs_csi.tf
@@ -18,10 +18,12 @@ data "aws_iam_policy_document" "ebs_csi" {
       "ec2:ModifyVolume",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypes",
       "ec2:DescribeSnapshots",
       "ec2:DescribeTags",
       "ec2:DescribeVolumes",
       "ec2:DescribeVolumesModifications",
+      "ec2:DescribeVolumeStatus",
       "ec2:EnableFastSnapshotRestores",
     ]
 
@@ -128,7 +130,10 @@ data "aws_iam_policy_document" "ebs_csi" {
   }
 
   statement {
-    actions   = ["ec2:DeleteSnapshot"]
+    actions = [
+      "ec2:DeleteSnapshot",
+      "ec2:LockSnapshot",
+    ]
     resources = ["*"]
 
     condition {
@@ -139,7 +144,10 @@ data "aws_iam_policy_document" "ebs_csi" {
   }
 
   statement {
-    actions   = ["ec2:DeleteSnapshot"]
+    actions = [
+      "ec2:DeleteSnapshot",
+      "ec2:LockSnapshot",
+    ]
     resources = ["*"]
 
     condition {


### PR DESCRIPTION
## Summary

Aligns the EBS CSI IAM policy with the upstream [example-iam-policy.json](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/example-iam-policy.json).

The following permissions were missing:

| Permission | Needed since | Policy doc updated | PR |
|---|---|---|---|
| `ec2:DescribeInstanceTypes` | v1.59.0 | [v1.59.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v1.59.0/docs/example-iam-policy.json) | [kubernetes-sigs/aws-ebs-csi-driver#2916](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2916) |
| `ec2:DescribeVolumeStatus` | v1.46.0 | [v1.46.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v1.46.0/docs/example-iam-policy.json) | [kubernetes-sigs/aws-ebs-csi-driver#2568](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2568) |
| `ec2:LockSnapshot` | v1.55.0 (feature) | [v1.59.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v1.59.0/docs/example-iam-policy.json) (doc fix) | [kubernetes-sigs/aws-ebs-csi-driver#2921](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2921) |

- **`ec2:DescribeInstanceTypes`** — The driver now calls this at runtime to handle instances with multiple EBS cards. The changelog warns this will become mandatory in a future release.
- **`ec2:DescribeVolumeStatus`** — Required by the `blockAttachUntilInitialized` StorageClass parameter to poll volume initialization status after snapshot restore.
- **`ec2:LockSnapshot`** — Required by the snapshot locking feature (VolumeSnapshotClass parameters to lock EBS snapshots after creation). Feature shipped in v1.55.0 but the example policy was only updated in v1.59.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Human note
ec2:DescribeInstanceTypes is explicitly mentioned in the changelog: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md#v1590 - claude picked up the other two on the way - they sound legit to me but careful review is probably in order.