### PR TITLE
fix: Add ec2:DescribeSecurityGroups to aws_vpc_cni policy

### DIFF
--- a/aws_vpc_cni.tf
+++ b/aws_vpc_cni.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "vpc_cni" {
         "ec2:DescribeTags",
         "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeInstanceTypes",
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",


### PR DESCRIPTION
## Description

Adds the missing `ec2:DescribeSecurityGroups` permission to the IPv4 statement in `aws_vpc_cni.tf`. This permission is required for VPC CNI **v1.22.0+** and was added to the upstream sample IPv4 policy between `v1.21.2` and `v1.22.1`.

Closes #60. Related upstream issue: aws/amazon-vpc-cni-k8s#3705.

## Why

VPC CNI v1.22.x introduced auto-discovery of custom security groups tagged with `kubernetes.io/role/cni=1` for ENIs in secondary subnets. The discovery call happens during IPAMD initialization, *not* lazily, and is gated by the **default-on** subnet discovery feature:

`pkg/ipamd/ipamd.go` (v1.22.1):

```go
if !c.disableENIProvisioning {
    if err := c.awsClient.RefreshSGIDs(ctx, primaryENIMac, c.dataStoreAccess); err != nil {
        return err
    }
    if c.useSubnetDiscovery && !c.useCustomNetworking {
        if err := c.awsClient.RefreshCustomSGIDs(ctx, c.dataStoreAccess); err != nil {
            return err   // <-- IPAMD aborts; :50051 never opens
        }
    }
    ...
```

Defaults (`pkg/ipamd/ipamd.go`):

```go
func UseCustomNetworkCfg() bool { return parseBoolEnvVar(envCustomNetworkCfg, false) }  // false
func UseSubnetDiscovery()  bool { return parseBoolEnvVar(envSubnetDiscovery, true) }    // true
```

So with default env settings, `RefreshCustomSGIDs` -> `ec2.DescribeSecurityGroups` is invoked at startup. Without the IAM permission, IPAMD never opens the gRPC port `:50051`, readiness/liveness probes time out, and `aws-node` pods stay `1/2 Running` indefinitely.

## Upstream policy diff

`testdata/amazon-eks-cni-policy-v4.json` between `v1.21.2` and `v1.22.1`:

```diff
                 "ec2:DescribeInstanceTypes",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
                 "ec2:DetachNetworkInterface",
```

`ec2:DescribeSubnets` is already present in the module's IPv4 statement — only `ec2:DescribeSecurityGroups` is missing.

## Change

```diff
         "ec2:DescribeInstanceTypes",
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DetachNetworkInterface",
```

## Notes

- Scope intentionally limited to the IPv4 statement to mirror the upstream sample policy update. The IPv6 statement is left unchanged; happy to extend if maintainers prefer.
- No examples needed to update — this is a bare permission addition to an already-tested code path.